### PR TITLE
Server Time Added

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,13 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile fileTree(include: ['*.jar'], dir: 'libs')
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'commons-net:commons-net:3.6'
     testCompile 'junit:junit:4.12'
 }
 

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -15,6 +15,14 @@
       },
       "oauth_client": [
         {
+          "client_id": "422420184850-e9npogv4rtsla1o0por7i3sbda344qce.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.yaho.facelapse",
+            "certificate_hash": "d7672df250911798d8cb395fd57963ae742e0dff"
+          }
+        },
+        {
           "client_id": "422420184850-jt9idemnpg51khkeg309bbd142ciusk7.apps.googleusercontent.com",
           "client_type": 3
         }
@@ -29,8 +37,13 @@
           "status": 1
         },
         "appinvite_service": {
-          "status": 1,
-          "other_platform_oauth_client": []
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "422420184850-jt9idemnpg51khkeg309bbd142ciusk7.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
         },
         "ads_service": {
           "status": 2

--- a/app/src/main/java/com/yaho/facelapse/MainActivity.java
+++ b/app/src/main/java/com/yaho/facelapse/MainActivity.java
@@ -6,12 +6,14 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 import android.view.Window;
-import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.util.concurrent.ExecutionException;
+
 public class MainActivity extends AppCompatActivity {
 
+    Validate test;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -35,13 +37,16 @@ public class MainActivity extends AppCompatActivity {
         Typeface font3 = Typeface.createFromAsset(getAssets(), "AmaticSC-Bold.ttf");
         tv3.setTypeface(font3);
 
+        test = new Validate();
+
     }
 
-    public void onClick(View view) {
+    public void onClick(View view) throws ExecutionException, InterruptedException {
         switch (view.getId()){
             case R.id.buttonselfie:
                 // SELFIE 버튼이 눌렸을 때
-                Toast.makeText(this, "SELFIE button clicked", Toast.LENGTH_LONG).show();
+                Toast.makeText(this, test.getServertime(), Toast.LENGTH_LONG).show();
+                Toast.makeText(this, test.getLocaltime(), Toast.LENGTH_LONG).show();
                 break;
             case R.id.buttonalbum:
                 // ALBUM 버튼이 눌렸을 때

--- a/app/src/main/java/com/yaho/facelapse/ServerTime.java
+++ b/app/src/main/java/com/yaho/facelapse/ServerTime.java
@@ -1,0 +1,40 @@
+package com.yaho.facelapse;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.apache.commons.net.ntp.NTPUDPClient;
+import org.apache.commons.net.ntp.TimeInfo;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class ServerTime extends AsyncTask<String, Void, Long> {
+
+    public static final String TIME_SERVER = "time.google.com";
+
+    private Exception exception;
+
+    protected Long doInBackground(String... urls) {
+        NTPUDPClient timeClient = new NTPUDPClient();
+        timeClient.setDefaultTimeout(3000);
+        InetAddress inetAddress = null;
+        TimeInfo timeInfo = null;
+
+        try {
+            inetAddress = InetAddress.getByName(TIME_SERVER);
+            timeInfo = timeClient.getTime(inetAddress);
+            long localTime = timeInfo.getReturnTime();
+            long serverTime = timeInfo.getMessage().getTransmitTimeStamp().getTime();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            Log.e("UnknownHostException: ", e.getMessage());
+        } catch (IOException e) {
+            e.printStackTrace();
+            Log.e("IOException: ", e.getMessage());
+        }
+        return timeInfo.getMessage().getTransmitTimeStamp().getTime();
+    }
+}
+

--- a/app/src/main/java/com/yaho/facelapse/Validate.java
+++ b/app/src/main/java/com/yaho/facelapse/Validate.java
@@ -1,0 +1,47 @@
+package com.yaho.facelapse;
+
+import android.util.Log;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
+
+public class Validate {
+    long servertime;
+    long localtime;
+
+    public void setServertime() throws ExecutionException, InterruptedException {
+        this.servertime = new ServerTime().execute().get();
+    }
+
+    public void setLocaltime() {
+        this.localtime = System.currentTimeMillis();
+    }
+
+    public String getServertime() {
+        try {
+            setServertime();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        setLocaltime();
+        Log.e("Servertime", Long.toString(servertime));
+        return returnString(servertime);
+    }
+
+    public String getLocaltime() {
+        setLocaltime();
+        Log.e("Localtime", Long.toString(localtime));
+        return returnString(localtime);
+    }
+
+    private String returnString(long time){
+        Date current = new Date(time);
+        SimpleDateFormat transFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        return transFormat.format(current);
+    }
+
+}


### PR DESCRIPTION
  In build.gradle:
    - Apache common net 3.6 library was added to use NTPUDPClient and TimeInfo Class.

  New Classes(ServerTime, Validate):
    - ServerTime class retrieves servertime from Google NTP server with AsyncTask
    - Validate class holds servertime and localtime (device) and these are renewed when time values are requested.
    - Compare function that gets difference between server and local time will be added to prevent user from manually changing the logic of the program

  MainActivity was modified:
    - To test Validate class